### PR TITLE
bugfix: removes gray background color added to header logos with transparent backgrounds

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -3720,6 +3720,7 @@ hr {
       margin: 0 auto; } }
 
 .site-header__logo-image {
+  background-color: transparent !important;
   display: block; }
   @media only screen and (min-width: 750px) {
     .site-header__logo-image {


### PR DESCRIPTION
This one is a bug that exist in the original theme but figured I would push it here since I'm adding to my fork.

Logo images with transparent backgrounds end up with a gray background block even though it should be matching the sites background-color.

![image](https://user-images.githubusercontent.com/2039258/146874442-38d2ed10-40ac-43df-9563-84a8b8551594.png)
![image](https://user-images.githubusercontent.com/2039258/146874456-ae049617-d36d-4f6d-b8b7-dbf562824cb3.png)


If you create some issues, then I'd be happy to contribute to this effort. Otherwise I will push over things as I run into them. 🙏